### PR TITLE
feat: add https, and cookie token

### DIFF
--- a/src/main/java/com/example/demo/controller/AuthController.java
+++ b/src/main/java/com/example/demo/controller/AuthController.java
@@ -4,6 +4,7 @@ import com.example.demo.common.ErrorResponse;
 import com.example.demo.common.SuccessResponse;
 import com.example.demo.jwt.JwtUtil;
 import com.example.demo.service.KakaoService;
+import com.example.demo.util.CookieUtil;
 import jakarta.servlet.http.HttpServletResponse;
 import lombok.RequiredArgsConstructor;
 import org.springframework.http.HttpStatus;
@@ -26,15 +27,12 @@ public class AuthController {
             String accessToken = jwtUtil.generateAccessToken(userId.toString());
             String refreshToken = jwtUtil.generateRefreshToken(userId.toString());
 
-            String formattedAccessCookie = String.format("accessToken=%s; HttpOnly; Path=/; Max-Age=%d; SameSite=None", accessToken, 60 * 60);
-            String formattedRefreshCookie = String.format("refreshToken=%s; HttpOnly; Path=/; Max-Age=%d; SameSite=None", refreshToken, 60 * 60 * 24 * 7);
-
-            response.addHeader("Set-Cookie", formattedAccessCookie);
-            response.addHeader("Set-Cookie", formattedRefreshCookie);
+            CookieUtil.addCookie(response, "accessToken", accessToken, 60 * 60);
+            CookieUtil.addCookie(response, "refreshToken", refreshToken, 60 * 60 * 24 * 7);
 
             return ResponseEntity.ok(new SuccessResponse("Login successful", ""));
         } catch (RuntimeException e) {
-            return ResponseEntity.status(HttpStatus.FORBIDDEN).body(new ErrorResponse("", "Access denied"));
+            return ResponseEntity.status(HttpStatus.UNAUTHORIZED).body(new ErrorResponse("", "Access denied"));
         }
     }
 }

--- a/src/main/java/com/example/demo/jwt/JwtAuthenticationFilter.java
+++ b/src/main/java/com/example/demo/jwt/JwtAuthenticationFilter.java
@@ -3,6 +3,7 @@ package com.example.demo.jwt;
 import com.example.demo.service.CustomUserDetailsService;
 import jakarta.servlet.FilterChain;
 import jakarta.servlet.ServletException;
+import jakarta.servlet.http.Cookie;
 import jakarta.servlet.http.HttpServletRequest;
 import jakarta.servlet.http.HttpServletResponse;
 import lombok.RequiredArgsConstructor;
@@ -15,6 +16,8 @@ import org.springframework.stereotype.Component;
 import org.springframework.web.filter.OncePerRequestFilter;
 
 import java.io.IOException;
+import java.util.Arrays;
+import java.util.Optional;
 
 @Slf4j
 @Component
@@ -27,15 +30,14 @@ public class JwtAuthenticationFilter extends OncePerRequestFilter {
     @Override
     protected void doFilterInternal(HttpServletRequest request, HttpServletResponse response, FilterChain chain)
             throws ServletException, IOException {
-        String authHeader = request.getHeader("Authorization");
+        String token = getTokenFromCookies(request);
 
-        if (authHeader == null || !authHeader.startsWith("Bearer ")) {
+        if (token == null) {
             chain.doFilter(request, response);
             return;
         }
 
         try {
-            String token = authHeader.substring(7);
             String userId = jwtUtil.extractUserId(token);
 
             if (userId != null && SecurityContextHolder.getContext().getAuthentication() == null) {
@@ -56,5 +58,18 @@ public class JwtAuthenticationFilter extends OncePerRequestFilter {
             log.error("인증 실패!, {}", e.getLocalizedMessage());
             chain.doFilter(request, response);
         }
+    }
+
+    private String getTokenFromCookies(HttpServletRequest request) {
+        Cookie[] cookies = request.getCookies();
+        if (cookies != null) {
+            Optional<Cookie> tokenCookie = Arrays.stream(cookies)
+                    .filter(cookie -> "accessToken".equals(cookie.getName()))
+                    .findFirst();
+            if (tokenCookie.isPresent()) {
+                return tokenCookie.get().getValue();
+            }
+        }
+        return null;
     }
 }

--- a/src/main/java/com/example/demo/util/CookieUtil.java
+++ b/src/main/java/com/example/demo/util/CookieUtil.java
@@ -1,0 +1,20 @@
+package com.example.demo.util;
+
+import jakarta.servlet.http.HttpServletResponse;
+import org.springframework.http.ResponseCookie;
+
+public class CookieUtil {
+
+    public static void addCookie(HttpServletResponse response, String name, String value, int maxAge) {
+        ResponseCookie cookie = ResponseCookie.from(name, value)
+                .path("/")
+                .sameSite("None")
+                .httpOnly(true)
+                .secure(true)
+                .maxAge(maxAge)
+                .build();
+
+        response.addHeader("Set-Cookie", cookie.toString());
+    }
+
+}


### PR DESCRIPTION
"Authorization": "Bearer ${accessToken}" 헤더에서 토큰을 추출하는 방식에서
토큰 저장 쿠키에 Secure 옵션을 추가하면서 Https 로 변경,
추가 헤더를 받지 않아도 브라우저의 쿠키에서 토큰을 추출 하도록 변경.