### PR TITLE
refactor: CustomEmitter 생성자 수정

### DIFF
--- a/backend/src/main/java/yeoun/notification/service/SseService.java
+++ b/backend/src/main/java/yeoun/notification/service/SseService.java
@@ -38,7 +38,7 @@ public class SseService implements SseServiceInterface<Long, Integer> {
         emitter.onCompletion(()->removeSseEmitter(pk));
         emitter.onError((e)->removeSseEmitter(pk));
 
-        emitterMap.put(pk, new CustomEmitter(emitter));
+        emitterMap.put(pk, new CustomEmitter(emitter, SEE_RECONNECTION_SECOND));
 
         sendData(pk, "connect", firstData);
 
@@ -78,13 +78,15 @@ public class SseService implements SseServiceInterface<Long, Integer> {
     class CustomEmitter {
         private LocalDateTime createdAt;
         private SseEmitter emitter;
+        private Long reconnectSeconds;
 
         public boolean wasRecentlyConnected() {
-            return createdAt.plusSeconds(SEE_RECONNECTION_SECOND).isAfter(LocalDateTime.now());
+            return createdAt.plusSeconds(reconnectSeconds).isAfter(LocalDateTime.now());
         }
 
-        public CustomEmitter(SseEmitter emitter) {
+        public CustomEmitter(SseEmitter emitter, Long reconnectSeconds) {
             this.emitter = emitter;
+            this.reconnectSeconds = reconnectSeconds;
             this.createdAt = LocalDateTime.now();
         }
     }


### PR DESCRIPTION
CustomEmitter에서 사용 중인 SEE_RECONNECTION_SECOND 는 외부 상수이므로 외부 클래스에 강하게 의존하지 않도록 CustomEmitter 생성 시 reconnectionSecond를 주입 받도록 리팩토링 하였습니다.